### PR TITLE
Create redirect model and migrate on load

### DIFF
--- a/Mirin.cabal
+++ b/Mirin.cabal
@@ -25,4 +25,5 @@ executable Mirin
                      , yaml
                      , persistent
                      , persistent-mysql
+                     , persistent-template
                      , monad-logger


### PR DESCRIPTION
All of the LANGUAGE pragmas are needed to use `share` which generates a lot of model related code for use from a database table definition.